### PR TITLE
fix argument to delay

### DIFF
--- a/Dumbrise.ino
+++ b/Dumbrise.ino
@@ -92,7 +92,7 @@ void pulseWhite(float fadeUpMinutes, float fadeDownMinutes) {
   for(int j= NUM_STEPS; j>=0; j--) { // Ramp down from 255 to 0
     strip.fill(strip.Color(0, 0, 0, strip.gamma8(j)));
     strip.show();
-    delay(wait);
+    delay(delayms);
   }
 }
 


### PR DESCRIPTION
The delay arguments had been renamed from wait to delayms. One of
the uses was missed.